### PR TITLE
Fix parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
-cookie
-
 *.pyc
-
+venv*
+cookie
 unexpected_output.html
+

--- a/courtreader/districtcourtopener.py
+++ b/courtreader/districtcourtopener.py
@@ -68,7 +68,13 @@ class DistrictCourtOpener:
         data = urllib.urlencode(data)
         url = self.url('caseSearch.do')
         page = self.opener.open(url, data)
-        return BeautifulSoup(page.read())
+        content = ''
+        for line in page:
+            if '<a href="caseSearch.do?formAction=caseDetails' in line:
+                line = line.replace('/>', '>')
+            content += line
+        soup = BeautifulSoup(content)
+        return soup
     
     def open_case_details(self, case):
         url = self.url(case['details_url'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+beautifulsoup4==4.3.2


### PR DESCRIPTION
The court site has some HTML that looks like `<a href="blah" />Link</a>`. So the parser saw that self closing `a` tag and closed the rest of the tags automatically and left the rest of the HTML out. For some reason, this wasn't happening on my computer until I ran the script in virtualenv.
